### PR TITLE
Kb skip blank lines

### DIFF
--- a/openpyxl_dictreader.py
+++ b/openpyxl_dictreader.py
@@ -33,6 +33,9 @@ class DictReader(object):
                 self._fieldnames = next(self.reader)
             except StopIteration:
                 pass
+
+        # screen out `None` values. They represent blank cells.
+        self._fieldnames = [f for f in self._fieldnames if f is not None]
         self.line_num += 1
         return self._fieldnames
 
@@ -56,7 +59,7 @@ class DictReader(object):
             
         d = dict(zip(self.fieldnames, row))
         lf = len(self.fieldnames)
-        lr = len(row)
+        lr = sum(cell is not None for cell in row) # number of non-blank cell in row
         if lf < lr:
             d[self.restkey] = row[lf:]
         elif lf > lr:

--- a/openpyxl_dictreader.py
+++ b/openpyxl_dictreader.py
@@ -35,7 +35,8 @@ class DictReader(object):
                 pass
 
         # screen out `None` values. They represent blank cells.
-        self._fieldnames = [f for f in self._fieldnames if f is not None]
+        if self._fieldnames:
+            self._fieldnames = [f for f in self._fieldnames if f is not None]
         self.line_num += 1
         return self._fieldnames
 

--- a/openpyxl_dictreader.py
+++ b/openpyxl_dictreader.py
@@ -49,8 +49,11 @@ class DictReader(object):
         row = next(self.reader)
         self.line_num += 1
 
-        while row == []:
-            row = next(iter(self.ws_list))
+        # skip blank lines
+        while all(cell is None for cell in row):
+            row = next(self.reader)
+            self.line_num += 1
+            
         d = dict(zip(self.fieldnames, row))
         lf = len(self.fieldnames)
         lr = len(row)

--- a/tests/test_dictreader.py
+++ b/tests/test_dictreader.py
@@ -97,7 +97,7 @@ class TestDictFields(unittest.TestCase):
     #  E           AssertionError: Lists differ: ['f1', 'f2', None, None, None, None] != ['f1', 'f2']
     #  E           First list contains 4 additional elements.
 
-    @unittest.skip("DictReader does not handle 'restkey' option yet")
+    # @unittest.skip("DictReader does not handle 'restkey' option yet")
     def test_read_long_with_rest_no_fieldnames(self):
         wb = Workbook()
         ws = wb.active
@@ -119,7 +119,7 @@ class TestDictFields(unittest.TestCase):
 
     # The dict reader does not deal with 'restval' yet.
     #    It is expecting blank return values but is getting 'None'
-    @unittest.skip("DictReader does not handle 'restval' option yet")
+    # @unittest.skip("DictReader does not handle 'restval' option yet")
     def test_read_short(self):
         wb = Workbook()
         ws = wb.active

--- a/tests/test_dictreader.py
+++ b/tests/test_dictreader.py
@@ -4,9 +4,6 @@
 import unittest
 from io import BytesIO
 from tempfile import TemporaryFile
-from itertools import permutations
-from textwrap import dedent
-from collections import OrderedDict
 from openpyxl import Workbook
 from openpyxl_dictreader import DictReader
 

--- a/tests/test_dictreader.py
+++ b/tests/test_dictreader.py
@@ -185,7 +185,6 @@ class TestDictFields(unittest.TestCase):
                 },
             )
 
-    @unittest.skip("DictReader does not handle blank lines yet")
     def test_read_with_blanks(self):
         wb = Workbook()
         ws = wb.active

--- a/tests/test_dictreader.py
+++ b/tests/test_dictreader.py
@@ -51,6 +51,14 @@ class TestDictFields(unittest.TestCase):
             self.assertEqual(next(reader), {"John": 1, "Sebastian": 2, "Bach": 3})
             self.assertEqual(reader.fieldnames, ['John', 'Sebastian', 'Bach'])
 
+    def test_read_dict_fieldnames_from_blank_file(self):
+        wb = Workbook()
+        ws = wb.active
+        with TemporaryFile() as fileobj:
+            wb.save(fileobj)
+            reader = DictReader(fileobj)
+            self.assertIsNone(reader.fieldnames)
+
     def test_read_dict_fieldnames_chain(self):
         import itertools
 

--- a/tests/test_dictreader.py
+++ b/tests/test_dictreader.py
@@ -38,6 +38,19 @@ class TestDictFields(unittest.TestCase):
             self.assertEqual(next(reader), {"f1": "1", "f2": "2", "f3": "abc"})
             self.assertEqual(reader.fieldnames, ["f1", "f2", "f3"])
 
+    def test_read_dict_set_fieldnames(self):
+        wb = Workbook()
+        ws = wb.active
+        ws["A1"] = 1
+        ws["B1"] = 2
+        ws["C1"] = 3
+        with TemporaryFile() as fileobj:
+            wb.save(fileobj)
+            reader = DictReader(fileobj)
+            reader.fieldnames = ['John', 'Sebastian', 'Bach']
+            self.assertEqual(next(reader), {"John": 1, "Sebastian": 2, "Bach": 3})
+            self.assertEqual(reader.fieldnames, ['John', 'Sebastian', 'Bach'])
+
     def test_read_dict_fieldnames_chain(self):
         import itertools
 


### PR DESCRIPTION
Hello Frank,

  Got another PR for you.
  This one allows DictReader to skip blank lines, just like the csv version.
  It also implements the `restkey=` and `restval=` arguments that are available in the csv.DictReader

  In addition, it turns on the tests for these features.

  The key to all three of the new features is recognizing that openpyxl returns `None` to represent a blank cell instead of an empty list.

  I'm having a lot a fun working on this.

Regards,
Kevin