### PR TITLE
Issue/roll back restkey

### DIFF
--- a/openpyxl_dictreader.py
+++ b/openpyxl_dictreader.py
@@ -63,7 +63,7 @@ class DictReader(object):
 
         d = dict(zip(self.fieldnames, row))
         lf = len(self.fieldnames)
-        lr = sum(cell is not None for cell in row) # number of non-blank cell in row
+        lr = len(row)
         if lf < lr:
             d[self.restkey] = row[lf:]
         elif lf > lr:

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ requirements = [
 
 setup(
     name='openpyxl-dictreader',
-    version='0.1.6',
+    version='0.1.7',
     description='A simple package to read openpyxl worksheets like a csv DictReader',
     long_description=readme,
     long_description_content_type='text/markdown',


### PR DESCRIPTION
After merging PR #15 there was an issue with an earlier change made to openpyxl_dictreader.py. This specifically concerned a line that manages restkey logic:

Rolled back:
```
lr = sum(cell is not None for cell in row) # number of non-blank cell in row
```

To:
```        
lr = len(row)
```

Restkey logic now works as expected.
